### PR TITLE
Feature of comment's reply

### DIFF
--- a/src/components/comment-reply-dialog.tsx
+++ b/src/components/comment-reply-dialog.tsx
@@ -1,0 +1,137 @@
+import { useDocumentEditor } from "@/contexts/document-editor-context";
+import { useFloatingComments } from "@/hooks/useFloatingComments";
+import { cn } from "@/lib/utils";
+import { useMemo, useState } from "react";
+import { RiDeleteBin2Line } from "react-icons/ri";
+
+const COMMENT_CARD_HEIGHT = 176;
+export default function CommentReplyDialog({ id, content, reply}) {
+  const {
+    comments,
+    updateComment,
+    removeComment,
+    activeCommentId,
+    selectActiveComment,
+    addCommentReply,
+    removeCommentReply,
+  } = useDocumentEditor();
+
+  const { commentCoords, maxTopValue } = useFloatingComments(
+    comments,
+    COMMENT_CARD_HEIGHT
+  );
+
+  const commentCoordsMap = useMemo(
+    () =>
+      commentCoords.reduce((acc, value) => {
+        return { ...acc, [value.id]: value.top };
+      }, {} as Record<string, number>),
+    [commentCoords]
+  );
+
+  const [commentText, setCommentText] = useState<string>("");
+
+  const [hideActions, setHideActions] = useState<Boolean>(false);
+
+  return (
+    <div
+      className={cn(
+          "card w-full bg-base-100 shadow-2xl absolute left-0 transition-all",
+          id === activeCommentId && "left-3"
+      )}
+      style={{
+          top: commentCoordsMap[id] - 500 || 0,
+      }}
+      key={id}
+      onClick={() => {
+        selectActiveComment(id);
+      }}
+    >
+      {/* repleis */}
+      <div>
+        {reply.map(({ id: childId, content }) => {
+          return (
+            <div
+              key={childId}
+              onClick={()=>{setHideActions(false)}}
+            >
+              <div className="flex ml-2 mb-5 mt-2">
+                {/* avatar */}
+                <span className="avatar placeholder card-title">
+                  <div className="bg-neutral-focus text-neutral-content rounded-full w-7">
+                      <span>U</span>
+                  </div>
+                </span>
+                {/* name and content */}
+                <span className="ml-2 mr-auto">
+                  {/* name */}
+                  <div className="text-xs mt-1 font-bold">username</div>
+                  {/* content */}
+                  <div className="text-sm">
+                  { content }
+                  </div>
+                </span>
+                {/* delete button */}
+                <span className="card-title">
+                  <button
+                    className="btn btn-error btn-xs ml-auto text-md"
+                    style={{borderRadius: '0'}}
+                    onClick={() => removeCommentReply(id, childId)}
+                  >
+                    <RiDeleteBin2Line />
+                  </button>
+                </span> 
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      {/* input area */}
+      <div className="card-body relative" style={{display: hideActions ? 'none': 'block'}}>
+        <div
+        className={cn(
+            "w-2 h-6 bg-secondary absolute -left-1 rounded-md",
+            id === activeCommentId ? "bg-primary" : "bg-secondary"
+        )}
+        ></div>
+        {/* prompt */}
+        <p className="card-title flex text-sm" >
+            Reply
+        </p>
+        {/* comment textarea */}
+        <textarea 
+          className="textarea textarea-bordered textarea-xs w-full max-w-xs"
+          style={{borderRadius: '5px'}}
+          placeholder="Type your comment here"
+          value={commentText}
+          onChange={(e) => setCommentText(e.target.value)}
+        />
+        {/*  actions: send and cancel button */}
+        <div className="btn-group ml-auto">
+          <button
+            className="btn btn-outline btn-xs text-md"
+            style={{borderRadius: '5px'}}
+            onClick={() => {
+              if(reply.length === 0) {
+                removeComment(id);
+              }
+              setHideActions(true);
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            className="btn btn-outline btn-xs text-md"
+            style={{borderRadius: '5px'}}
+            onClick={(e) => {
+              addCommentReply(id, commentText);
+              setCommentText("");
+            }}
+          >
+              Send
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/document-discussion.tsx
+++ b/src/components/document-discussion.tsx
@@ -3,6 +3,7 @@ import { useFloatingComments } from "@/hooks/useFloatingComments";
 import { cn } from "@/lib/utils";
 import { useMemo } from "react";
 import { RiDeleteBin2Line } from "react-icons/ri";
+import CommentReplyDialog from "./comment-reply-dialog";
 
 const COMMENT_CARD_HEIGHT = 176;
 
@@ -37,7 +38,7 @@ function DocumentDiscussion() {
         <h2 className="card-title">Comments</h2>
         <div className="divider" />
         <div className="relative">
-          {comments.map(({ id, content }) => {
+          {comments.map(({ id, content, reply }) => {
             return (
               <div
                 className={cn(
@@ -50,35 +51,8 @@ function DocumentDiscussion() {
                 key={id}
                 onClick={() => selectActiveComment(id)}
               >
-                <div className="card-body relative">
-                  <div
-                    className={cn(
-                      "w-2 h-6 bg-secondary absolute -left-1 rounded-md",
-                      id === activeCommentId ? "bg-primary" : "bg-secondary"
-                    )}
-                  ></div>
-                  <p className="card-title flex">
-                    <div className="avatar placeholder">
-                      <div className="bg-neutral-focus text-neutral-content rounded-full w-12">
-                        <span>U</span>
-                      </div>
-                    </div>
-                    Username
-                    <button
-                      className="btn btn-error ml-auto text-md"
-                      onClick={() => removeComment(id)}
-                    >
-                      <RiDeleteBin2Line />
-                    </button>
-                  </p>
-                  <input
-                    type="text"
-                    placeholder="Type your comment here"
-                    value={content}
-                    className="input mt-2"
-                    onChange={(e) => updateComment(id, e.target.value)}
-                  />
-                </div>
+                {/* not necessary to transfer content but still reserved here */}
+                <CommentReplyDialog id={id} content={content} reply={reply} />
               </div>
             );
           })}


### PR DESCRIPTION
## Changes Made
Add a new feature of replying the comment.

## Why?
To make comment more user-friendly and sound.

## How to Use
1. Double click the text, type your comment in textarea and click the send button, a reply will be added.
2. Click the delete icon button and the specific reply will be deleted.
3. Click the cancel button, if there are existing replies, the action area will be hidden. When clicking the reply area, the action area will show again.
4. If Click the cancel button when there is no reply, the comment card will be removed.

## Screenshot
![Oct-20-2023 18-31-40](https://github.com/SketchPiece/fancy-editor/assets/72658271/7c17a317-1f89-4180-aeb4-c6b4fce167ed)

## Additional Information
I just complete the preliminary functions. There are some issues to do in the feature. 

## Issues
1. Issue 1: When comment for the same piece of text, the comment area will overlap.
2. Issue 2: The comment card seems too big. If we add a lot of comments, the right part of page will very long but the left text area is very short.

## Todo List
1. Realize import/export json including replies.
2. Add colored underline to the comment text.
3. Make the comment up to the top layer when clicking a comment, while some comments overlapped.(**Issue 1**)
4. Modify the comment cards‘s layout, including the height, interval.(**Issue 2**)
5. When we click the area out of a comment card, the comment card's action area(textarea, buttons) will be hidden. It helps save space for the comment area.(**Issue 2**)
6. Make the components more beautiful.
